### PR TITLE
Refactoring DashboardHelper

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -9,7 +9,7 @@ class DashboardController < ApplicationController
 	def private
 		user_pushups = Pushup.where(user_id: current_user.id)
 		@pushups = hashify_team(user_pushups)
-		@dates = @pushups.keys.map {|p| p.strftime("%b %d")}
+		@dates = @pushups.keys.map {|p| p.strftime("%b %d")}.sort
 		@user_amounts = combine_daily_logs(@pushups)
 		@user_sum = combine_team_pushups(@pushups.keys, @user_amounts)
 
@@ -21,7 +21,7 @@ class DashboardController < ApplicationController
 		team_pushups = current_team_pushups(@subdomain)
 
 		@pushups = hashify_team(team_pushups) # creates hash of pushup log date:amount
-		@dates = @pushups.keys.map {|p| p.strftime("%b %d")}
+		@dates = @pushups.keys.map {|p| p.strftime("%b %d")}.sort
 		@team_amounts = combine_daily_logs(@pushups) # when multiple entries exist on a single date
 		@combined_team_pushups = combine_team_pushups(@pushups.keys, @team_amounts)
 

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,30 +1,13 @@
 module DashboardHelper
 
 	def hashify_team(pushups, output={})
-		pushups.each do |p|
-			output[p.date] = []
-		end
-		output.each do |date, amounts|
-			relevant_pushups = pushups.select {|p| p.date == date}
-			relevant_pushups.each do |rel|
-				amounts << rel.amount.to_i
-			end
-		end
-		output.sort.to_h # sort method returns array, so revert back to hash
+		pushups.map { |p| output.key?(p.date) ? output[p.date] << p.amount : output[p.date] = [p.amount] }
+		output
 	end
 
 	def combine_daily_logs(pushups, arr=[])
-		pushups.values.each do |values|
-			entries = values.count
-			counter = 0
-			total = 0
-			while counter < entries
-				total += values[counter]
-				counter += 1
-			end
-			arr << total
-		end
-			arr
+		pushups.values.each { |values| arr << values.reduce(0,:+) }
+		arr
 	end
 
 	def combine_team_pushups(dates, amounts, output={})


### PR DESCRIPTION
A little refactoring of ```hashify_team``` and ```combine_daily_logs```, also moved ```sort``` to @dates. As I found that backlogged pushups were not getting sorted on the line graph of the dashboard. For example: Adding pushups on Aug 12, then adding pushups to be backed dated for Aug. 11 would still appear after the Aug. 12 data.